### PR TITLE
bump pluggable monitor lib to fix double CLOSE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,7 @@
 module github.com/arduino/serial-monitor
 
 require (
-	github.com/arduino/go-paths-helper v1.6.1 // indirect
-	github.com/arduino/go-properties-orderedmap v1.6.0 // indirect
-	github.com/arduino/pluggable-monitor-protocol-handler v0.9.0
+	github.com/arduino/pluggable-monitor-protocol-handler v0.9.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	go.bug.st/serial v1.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,5 @@
-github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
-github.com/arduino/go-paths-helper v1.6.1 h1:lha+/BuuBsx0qTZ3gy6IO1kU23lObWdQ/UItkzVWQ+0=
-github.com/arduino/go-paths-helper v1.6.1/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.4.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
-github.com/arduino/go-properties-orderedmap v1.6.0 h1:gp2JoWRETtqwsZ+UHu/PBuYWYH2x2+d+uipDxS4WmvM=
-github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
-github.com/arduino/pluggable-monitor-protocol-handler v0.9.0 h1:N2wk5D//4wVQIGVtyLH2wMufJa6+q9bl0P1/G3DKYXM=
-github.com/arduino/pluggable-monitor-protocol-handler v0.9.0/go.mod h1:nWW6xPvKZH2PRGaIxolKOcYVBuh5mOCam3avYaaH7No=
+github.com/arduino/pluggable-monitor-protocol-handler v0.9.1 h1:uv3o5uaDXsmu5FSp9jSk6rn4awy//ArQ7BpDeIAV7GY=
+github.com/arduino/pluggable-monitor-protocol-handler v0.9.1/go.mod h1:vMG8tgHyE+hli26oT0JB/M7NxUMzzWoU5wd6cgJQRK4=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,12 +9,9 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.bug.st/serial v1.3.2 h1:6BFZZd/wngoL5PPYYTrFUounF54SIkykHpT98eq6zvk=


### PR DESCRIPTION
Use new lib version (0.9.1)[https://github.com/arduino/pluggable-monitor-protocol-handler/releases/tag/v0.9.1] to fix the double close bug:
If you used to type two CLOSE in a row, the second one did not have output