### PR TITLE
Correct example commands and output in README to reflect actual behavior of tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The response to the command is:
 ```json
 {
   "eventType": "hello",
-  "protocolVersion": 1,
-  "message": "OK"
+  "message": "OK",
+  "protocolVersion": 1
 }
 ```
 
@@ -42,17 +42,18 @@ The response to the command is:
 
 The `DESCRIBE` command returns a description of the communication port. The description will have metadata about the port configuration, and which parameters are available:
 
+<!-- prettier-ignore -->
 ```json
 {
-  "event": "describe",
-  "message": "ok",
+  "eventType": "describe",
+  "message": "OK",
   "port_description": {
     "protocol": "serial",
     "configuration_parameters": {
       "baudrate": {
         "label": "Baudrate",
         "type": "enum",
-        "values": [
+        "value": [
           "300",
           "600",
           "750",
@@ -73,22 +74,38 @@ The `DESCRIBE` command returns a description of the communication port. The desc
         ],
         "selected": "9600"
       },
-      "parity": {
-        "label": "Parity",
-        "type": "enum",
-        "values": ["None", "Even", "Odd", "Mark", "Space"],
-        "selected": "None"
-      },
       "bits": {
         "label": "Data bits",
         "type": "enum",
-        "values": ["5", "6", "7", "8", "9"],
+        "value": [
+          "5",
+          "6",
+          "7",
+          "8",
+          "9"
+        ],
         "selected": "8"
+      },
+      "parity": {
+        "label": "Parity",
+        "type": "enum",
+        "value": [
+          "None",
+          "Even",
+          "Odd",
+          "Mark",
+          "Space"
+        ],
+        "selected": "None"
       },
       "stop_bits": {
         "label": "Stop bits",
         "type": "enum",
-        "values": ["1", "1.5", "2"],
+        "value": [
+          "1",
+          "1.5",
+          "2"
+        ],
         "selected": "1"
       }
     }
@@ -100,7 +117,7 @@ Each parameter has a unique name (`baudrate`, `parity`, etc...), a `type` (in th
 
 The parameter name can not contain spaces, and the allowed characters in the name are alphanumerics, underscore `_`, dot `.`, and dash `-`.
 
-The `enum` types must have a list of possible `values`.
+The `enum` types must have a list of possible `value`.
 
 The client/IDE may expose these configuration values to the user via a config file or a GUI, in this case the `label` field may be used for a user readable description of the parameter.
 
@@ -114,8 +131,8 @@ The response to the command is:
 
 ```JSON
 {
-  "event": "configure",
-  "message": "ok",
+  "eventType": "configure",
+  "message": "OK"
 }
 ```
 
@@ -123,9 +140,9 @@ or if there is an error:
 
 ```JSON
 {
-  "event": "configure",
-  "error": true,
-  "message": "invalid value for parameter baudrate: 123456"
+  "eventType": "configure",
+  "message": "invalid value for parameter baudrate: 123456",
+  "error": true
 }
 ```
 
@@ -150,8 +167,8 @@ The answer to the `OPEN` command is:
 
 ```JSON
 {
-  "event": "open",
-  "message": "ok"
+  "eventType": "open",
+  "message": "OK"
 }
 ```
 
@@ -159,7 +176,7 @@ If the monitor tool cannot communicate with the board, or if the tool can not co
 
 ```JSON
 {
-  "event": "open",
+  "eventType": "open",
   "error": true,
   "message": "unknown port /dev/ttyACM23"
 }
@@ -171,8 +188,9 @@ Once the port is opened, it may be unexpectedly closed at any time due to hardwa
 
 ```JSON
 {
-  "event": "port_closed",
-  "message": "serial port disappeared!"
+  "eventType": "port_closed",
+  "message": "serial port disappeared!",
+  "error": true
 }
 ```
 
@@ -180,8 +198,9 @@ or
 
 ```JSON
 {
-  "event": "port_closed",
-  "message": "lost TCP/IP connection with the client!"
+  "eventType": "port_closed",
+  "message": "lost TCP/IP connection with the client!",
+  "error": true
 }
 ```
 
@@ -191,8 +210,8 @@ The `CLOSE` command will close the currently opened port and close the TCP/IP co
 
 ```JSON
 {
-  "event": "close",
-  "message": "ok"
+  "eventType": "close",
+  "message": "OK"
 }
 ```
 
@@ -200,7 +219,7 @@ or in case of error
 
 ```JSON
 {
-  "event": "close",
+  "eventType": "close",
   "error": true,
   "message": "port already closed"
 }
@@ -227,7 +246,7 @@ If the client sends an invalid or malformed command, the monitor should answer w
 {
   "eventType": "command_error",
   "error": true,
-  "message": "Unknown command XXXX"
+  "message": "Command XXXX not supported"
 }
 ```
 
@@ -247,33 +266,70 @@ DESCRIBE
   "eventType": "describe",
   "message": "OK",
   "port_description": {
-    "protocol": "test",
+    "protocol": "serial",
     "configuration_parameters": {
-      "echo": {
-        "label": "echo",
-        "type": "enum",
-        "value": [
-          "on",
-          "off"
-        ],
-        "selected": "on"
-      },
-      "speed": {
+      "baudrate": {
         "label": "Baudrate",
         "type": "enum",
         "value": [
+          "300",
+          "600",
+          "750",
+          "1200",
+          "2400",
+          "4800",
           "9600",
           "19200",
           "38400",
           "57600",
-          "115200"
+          "115200",
+          "230400",
+          "460800",
+          "500000",
+          "921600",
+          "1000000",
+          "2000000"
         ],
         "selected": "9600"
+      },
+      "bits": {
+        "label": "Data bits",
+        "type": "enum",
+        "value": [
+          "5",
+          "6",
+          "7",
+          "8",
+          "9"
+        ],
+        "selected": "8"
+      },
+      "parity": {
+        "label": "Parity",
+        "type": "enum",
+        "value": [
+          "None",
+          "Even",
+          "Odd",
+          "Mark",
+          "Space"
+        ],
+        "selected": "None"
+      },
+      "stop_bits": {
+        "label": "Stop bits",
+        "type": "enum",
+        "value": [
+          "1",
+          "1.5",
+          "2"
+        ],
+        "selected": "1"
       }
     }
   }
 }
-CONFIGURE speed 19200
+CONFIGURE baudrate 19200
 {
   "eventType": "configure",
   "message": "OK"
@@ -283,33 +339,70 @@ DESCRIBE
   "eventType": "describe",
   "message": "OK",
   "port_description": {
-    "protocol": "test",
+    "protocol": "serial",
     "configuration_parameters": {
-      "echo": {
-        "label": "echo",
-        "type": "enum",
-        "value": [
-          "on",
-          "off"
-        ],
-        "selected": "on"
-      },
-      "speed": {
+      "baudrate": {
         "label": "Baudrate",
         "type": "enum",
         "value": [
+          "300",
+          "600",
+          "750",
+          "1200",
+          "2400",
+          "4800",
           "9600",
           "19200",
           "38400",
           "57600",
-          "115200"
+          "115200",
+          "230400",
+          "460800",
+          "500000",
+          "921600",
+          "1000000",
+          "2000000"
         ],
         "selected": "19200"
+      },
+      "bits": {
+        "label": "Data bits",
+        "type": "enum",
+        "value": [
+          "5",
+          "6",
+          "7",
+          "8",
+          "9"
+        ],
+        "selected": "8"
+      },
+      "parity": {
+        "label": "Parity",
+        "type": "enum",
+        "value": [
+          "None",
+          "Even",
+          "Odd",
+          "Mark",
+          "Space"
+        ],
+        "selected": "None"
+      },
+      "stop_bits": {
+        "label": "Stop bits",
+        "type": "enum",
+        "value": [
+          "1",
+          "1.5",
+          "2"
+        ],
+        "selected": "1"
       }
     }
   }
 }
-OPEN 127.0.0.1:5678 "test"
+OPEN 127.0.0.1:5678 /dev/ttyACM0
 {
   "eventType": "open",
   "message": "OK"
@@ -320,10 +413,14 @@ CLOSE
   "message": "OK"
 }
 QUIT
+{
+  "eventType": "quit",
+  "message": "OK"
+}
 $
 ```
 
-On another terminal tab to test it you can run `nc -l -p 5678` before running the `OPEN 127.0.0.1:5678 "test"` command. After that you can write messages in that terminal tab and see them being echoed.
+On another terminal tab to test it you can run `nc -l -p 5678` before running the `OPEN 127.0.0.1:5678 /dev/ttyACM0` command. After that you can write messages in that terminal tab and see them being echoed.
 
 ## Security
 


### PR DESCRIPTION
The readme content seems to be based on [the "dummy-monitor" tool](https://github.com/arduino/pluggable-monitor-protocol-handler/tree/main/dummy-monitor) rather than on serial-monitor, and also outdated.

I have updated the commands and output to reflect the behavior of the tool from this repository.

The exception are some differences that are caused by bugs in the `github.com/arduino/pluggable-monitor-protocol-handler` tool:

- Incorrect `values` key names in DESCRIBE command response (arduino/arduino-cli#1738)
- Missing QUIT command response (https://github.com/arduino/pluggable-monitor-protocol-handler/issues/13)

The new readme content is written in expectation of specification compliance rather than reflecting the current buggy behavior.