### PR TITLE
Upgrade go-serial to `v1.4.1`

### DIFF
--- a/.licenses/serial-monitor/go/go.bug.st/serial.dep.yml
+++ b/.licenses/serial-monitor/go/go.bug.st/serial.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: go.bug.st/serial
-version: v1.4.0
+version: v1.4.1
 type: go
 summary: Package serial is a cross-platform serial library for the go language.
 homepage: https://pkg.go.dev/go.bug.st/serial

--- a/.licenses/serial-monitor/go/go.bug.st/serial/unixutils.dep.yml
+++ b/.licenses/serial-monitor/go/go.bug.st/serial/unixutils.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.bug.st/serial/unixutils
-version: v1.4.0
+version: v1.4.1
 type: go
 summary: 
 homepage: https://pkg.go.dev/go.bug.st/serial/unixutils
 license: bsd-3-clause
 licenses:
-- sources: serial@v1.4.0/LICENSE
+- sources: serial@v1.4.1/LICENSE
   text: |2+
 
     Copyright (c) 2014-2021, Cristian Maglie.
@@ -41,7 +41,7 @@ licenses:
     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 
-- sources: serial@v1.4.0/README.md
+- sources: serial@v1.4.1/README.md
   text: |-
     The software is release under a [BSD 3-clause license]
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/arduino/pluggable-monitor-protocol-handler v0.9.2
-	go.bug.st/serial v1.4.0
+	go.bug.st/serial v1.4.1
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-go.bug.st/serial v1.4.0 h1:IXHzPVbUBbql66lQZ1iV9LWzGXT5lh6S9gZxHK/KyQE=
-go.bug.st/serial v1.4.0/go.mod h1:z8CesKorE90Qr/oRSJiEuvzYRKol9r/anJZEb5kt304=
+go.bug.st/serial v1.4.1 h1:AwYUNixVf90XymNeJaUkMrPp+GZQe3RMFQmpVdHIUK8=
+go.bug.st/serial v1.4.1/go.mod h1:z8CesKorE90Qr/oRSJiEuvzYRKol9r/anJZEb5kt304=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=


### PR DESCRIPTION
This release solves:
* Intermittent spurious char sent on the serial port while IDLE
* Fix `ResetInputBuffers()` method on macosx