### PR TITLE
Cleanup IO buffers after opening the serial port

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,6 +156,11 @@ func (d *SerialMonitor) Open(boardPort string) (io.ReadWriter, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Clean up residual data in IO buffers
+	_ = serialPort.ResetInputBuffer() // do not error if resetting buffers fails
+	_ = serialPort.ResetOutputBuffer()
+
 	d.openedPort = true
 	d.serialPort = serialPort
 	return d.serialPort, nil


### PR DESCRIPTION
This change helps to remove "dirty" data that sometimes shows up when the user opens the serial port.