### PR TITLE
Added some missing baudrates

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,9 +59,14 @@ func NewSerialMonitor() *SerialMonitor {
 			Protocol: "serial",
 			ConfigurationParameter: map[string]*monitor.PortParameterDescriptor{
 				"baudrate": {
-					Label:    "Baudrate",
-					Type:     "enum",
-					Values:   []string{"300", "600", "750", "1200", "2400", "4800", "9600", "19200", "38400", "57600", "115200", "230400", "460800", "500000", "921600", "1000000", "2000000"},
+					Label: "Baudrate",
+					Type:  "enum",
+					Values: []string{
+						"300", "600", "750",
+						"1200", "2400", "4800", "9600",
+						"19200", "31250", "38400", "57600", "74880",
+						"115200", "230400", "250000", "460800", "500000", "921600",
+						"1000000", "2000000"},
 					Selected: "9600",
 				},
 				"parity": {


### PR DESCRIPTION
This is a tentative fix to add missing baud rates. It is known that there may be some issues on some OS, so testing is required to see if everything is working as expected.

The [Arduino IDE 1.8.x](https://github.com/arduino/Arduino/blob/57a931c9c4c084057417837239ad8136f8a7b1aa/app/src/processing/app/AbstractMonitor.java#L24) has the following baud rates in the selector:

```java
protected String[] serialRateStrings = {
  "300", "1200", "2400", "4800", "9600",
  "19200", "38400", "57600", "74880",
  "115200", "230400", "250000", "500000",
  "1000000", "2000000"};
```

I've added the missing `74880`, `250000`, and also `31250` (that is not available in the Arduino IDE 1.8.x).
