### PR TITLE
Revert "Cleanup IO buffers after opening the serial port"

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,11 +161,6 @@ func (d *SerialMonitor) Open(boardPort string) (io.ReadWriter, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// Clean up residual data in IO buffers
-	_ = serialPort.ResetInputBuffer() // do not error if resetting buffers fails
-	_ = serialPort.ResetOutputBuffer()
-
 	d.openedPort = true
 	d.serialPort = serialPort
 	return d.serialPort, nil


### PR DESCRIPTION
We had reports that the first lines received via serial are lost. This happens in particular on devices with fast native USB serial port.

We need to reopen https://github.com/arduino/arduino-ide/issues/927 to investigate the spurious chars.

This reverts commit c28e1a07656b7d3b5bd774e1b694cc2b3064d954.