### PR TITLE
De-link domain reference to avoid spurious link check failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ e-mail contact: security@arduino.cc
 
 ## License
 
-Copyright (c) 2018 ARDUINO SA (www.arduino.cc)
+Copyright (c) 2018 ARDUINO SA (www<!---->.arduino<!---->.cc)
 
 The software is released under the GNU General Public License, which covers the main body
 of the serial-monitor code. The terms of this license can be found at:


### PR DESCRIPTION
The license information in the readme contains a reference to www.arduino.cc. 

Text that looks like a domain is automatically linkified by common Markdown renderers ([including the one used by GitHub for repository contents](https://github.github.com/gfm/#autolinks-extension-)), converting this to a link to `http://www.arduino.cc`. The project infrastructure includes a check for broken links in the Markdown files. The [**markdown-link-check tool**](https://github.com/tcort/markdown-link-check) that provides this check is smart enough to also check these links produced by the autolink feature.

When the http://www.arduino.cc URL is opened normally, the Arduino website simply redirects to https://www.arduino.cc (note the https scheme) and all is well. However, when **markdown-link-check** attempts to load that URL, it fails spuriously with an HTTP 403 Forbidden response code (perhaps due to draconian security settings on the arduino.cc web infrastructure).

This could be fixed by changing the `www.arduino.cc` text to something like `[www.arduino.cc](https://www.arduino.cc)`. However, I don't think there was ever an intention for this reference to serve as a path for the reader of the text to visit that domain. Rather, it was added as an alternative way of identifying the entity referred to as "ARDUINO SA". For this reason, I think the most appropriate solution to the spurious link check failure is to prevent the autolinking of this text. This is done by injecting [HTML comment tags](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#html_comments) at strategic locations in the domain name. These tags cause the text to no longer be recognized as a domain name by the autolink system of the **markdown-link-check** tool and the GitHub Flavored Markdown renderer both. Other than it no longer being a link, the comment tags have no effect on the rendered text.